### PR TITLE
Use default when checking for invariants on cycle heads

### DIFF
--- a/lint/test/program/termination/nontermination.c
+++ b/lint/test/program/termination/nontermination.c
@@ -1,0 +1,6 @@
+void main() {
+  int x = 0;
+  while (1) {
+    x++;
+  }
+}

--- a/lint/test/program/termination/nontermination.graphml
+++ b/lint/test/program/termination/nontermination.graphml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
+<key id="programfile" attr.name="programfile" for="graph"/>
+<key id="programhash" attr.name="programhash" for="graph"/>
+<key id="sourcecodelang" attr.name="sourcecodelang" for="graph"/>
+<key id="producer" attr.name="producer" for="graph"/>
+<key id="specification" attr.name="specification" for="graph"/>
+<key id="creationtime" attr.name="creationtime" for="graph"/>
+<key id="witness-type" attr.name="witness-type" for="graph"/>
+<key id="architecture" attr.name="architecture" for="graph"/>
+<key id="entry" attr.name="entry" for="node">
+<default>false</default>
+</key>
+<key id="nodetype" attr.name="nodetype" for="node">
+<default>path</default>
+</key>
+<key id="violation" attr.name="violation" for="node">
+<default>false</default>
+</key>
+<key id="cyclehead" attr.name="cyclehead" for="node">
+<default>false</default>
+</key>
+<key id="invariant" attr.name="invariant" for="node">
+<default>true</default>
+</key>
+<key id="threadId" attr.name="threadId" for="edge"/>
+<key id="endline" attr.name="endline" for="edge"/>
+<key id="enterLoopHead" attr.name="enterLoopHead" for="edge">
+<default>false</default>
+</key>
+<key id="createThread" attr.name="createThread" for="edge"/>
+<key id="enterFunction" attr.name="enterFunction" for="edge"/>
+<key id="startline" attr.name="startline" for="edge"/>
+<key id="returnFrom" attr.name="returnFrom" for="edge"/>
+<key id="assumption" attr.name="assumption" for="edge"/>
+<key id="tokens" attr.name="tokens" for="edge"/>
+<key id="control" attr.name="control" for="edge"/>
+<key id="originfile" attr.name="originfile" for="edge">
+<default>/home/dominik/Work/witnesses/sv-witnesses/lint/test/program/termination/nontermination.c</default>
+</key>
+<key id="sourcecode" attr.name="sourcecode" for="edge"/>
+<graph edgedefault="directed">
+<data key="programfile">/home/dominik/Work/witnesses/sv-witnesses/lint/test/program/termination/nontermination.c</data>
+<data key="programhash">0b9671b024fd590a4436b67d5cf0c06a37adcee4</data>
+<data key="sourcecodelang">C</data>
+<data key="producer">Automizer</data>
+<data key="specification">CHECK( init(main()), LTL(F end) )
+
+</data>
+<data key="creationtime">2020-12-02T10:57:20</data>
+<data key="witness-type">violation_witness</data>
+<data key="architecture">32bit</data>
+<node id="N1">
+<data key="entry">true</data>
+</node>
+<node id="N0">
+<data key="cyclehead">true</data>
+</node>
+<node id="N2"/>
+<edge id="E0" source="N1" target="N0">
+<data key="endline">2</data>
+<data key="enterLoopHead">true</data>
+<data key="startline">2</data>
+<data key="originfile">/home/dominik/Work/witnesses/sv-witnesses/lint/test/program/termination/nontermination.c</data>
+<data key="sourcecode">int x = 0;</data>
+</edge>
+<edge id="E1" source="N0" target="N2">
+<data key="endline">3</data>
+<data key="startline">3</data>
+<data key="control">condition-true</data>
+<data key="originfile">/home/dominik/Work/witnesses/sv-witnesses/lint/test/program/termination/nontermination.c</data>
+<data key="sourcecode">[1]</data>
+</edge>
+<edge id="E2" source="N2" target="N0">
+<data key="endline">4</data>
+<data key="enterLoopHead">true</data>
+<data key="startline">4</data>
+<data key="originfile">/home/dominik/Work/witnesses/sv-witnesses/lint/test/program/termination/nontermination.c</data>
+<data key="sourcecode">x++</data>
+</edge>
+</graph>
+</graphml>

--- a/lint/test/program/termination/nontermination.graphml
+++ b/lint/test/program/termination/nontermination.graphml
@@ -36,11 +36,11 @@
 <key id="tokens" attr.name="tokens" for="edge"/>
 <key id="control" attr.name="control" for="edge"/>
 <key id="originfile" attr.name="originfile" for="edge">
-<default>/home/dominik/Work/witnesses/sv-witnesses/lint/test/program/termination/nontermination.c</default>
+<default>/home/user/sv-witnesses/lint/test/program/termination/nontermination.c</default>
 </key>
 <key id="sourcecode" attr.name="sourcecode" for="edge"/>
 <graph edgedefault="directed">
-<data key="programfile">/home/dominik/Work/witnesses/sv-witnesses/lint/test/program/termination/nontermination.c</data>
+<data key="programfile">/home/user/sv-witnesses/lint/test/program/termination/nontermination.c</data>
 <data key="programhash">0b9671b024fd590a4436b67d5cf0c06a37adcee4</data>
 <data key="sourcecodelang">C</data>
 <data key="producer">Automizer</data>
@@ -61,21 +61,21 @@
 <data key="endline">2</data>
 <data key="enterLoopHead">true</data>
 <data key="startline">2</data>
-<data key="originfile">/home/dominik/Work/witnesses/sv-witnesses/lint/test/program/termination/nontermination.c</data>
+<data key="originfile">/home/user/sv-witnesses/lint/test/program/termination/nontermination.c</data>
 <data key="sourcecode">int x = 0;</data>
 </edge>
 <edge id="E1" source="N0" target="N2">
 <data key="endline">3</data>
 <data key="startline">3</data>
 <data key="control">condition-true</data>
-<data key="originfile">/home/dominik/Work/witnesses/sv-witnesses/lint/test/program/termination/nontermination.c</data>
+<data key="originfile">/home/user/sv-witnesses/lint/test/program/termination/nontermination.c</data>
 <data key="sourcecode">[1]</data>
 </edge>
 <edge id="E2" source="N2" target="N0">
 <data key="endline">4</data>
 <data key="enterLoopHead">true</data>
 <data key="startline">4</data>
-<data key="originfile">/home/dominik/Work/witnesses/sv-witnesses/lint/test/program/termination/nontermination.c</data>
+<data key="originfile">/home/user/sv-witnesses/lint/test/program/termination/nontermination.c</data>
 <data key="sourcecode">x++</data>
 </edge>
 </graph>

--- a/lint/witnesslint/linter.py
+++ b/lint/witnesslint/linter.py
@@ -328,11 +328,14 @@ class WitnessLinter:
                     self.witness.cyclehead = parent.attrib.get("id", "")
                 else:
                     logging.warning("Found multiple cycleheads", data.sourceline)
-                if not self.invariant_present(parent):
-                    logging.warning(
-                        "Cyclehead does not contain an invariant",
-                        data.sourceline,
-                    )
+                # Check disabled for SV-COMP'21 as questions about the specification
+                # need to be resolved first, see
+                # https://github.com/sosy-lab/sv-witnesses/issues/32
+                # if not self.invariant_present(parent):
+                #     logging.warning(
+                #         "Cyclehead does not contain an invariant",
+                #         data.sourceline,
+                #     )
             elif data.text == "false":
                 logging.info(
                     "Specifying value 'false' for key 'cyclehead' is unnecessary",

--- a/lint/witnesslint/linter.py
+++ b/lint/witnesslint/linter.py
@@ -355,7 +355,7 @@ class WitnessLinter:
     def invariant_present(self, elem):
         if witness.INVARIANT in self.key_defaults:
             return True
-        for child in parent:
+        for child in elem:
             if (
                 child.tag.rpartition("}")[2] == witness.DATA
                 and child.attrib.get(witness.KEY) == witness.INVARIANT


### PR DESCRIPTION
The linter complains about `cyclehead`s that do not have an `invariant` attribute. This warning occurs for us in many of Ultimate's termination witnesses.

This change relaxes that check to take into account the default value of the `invariant` key, i.e., if such a default is specified, no warning is issued.

