### PR TITLE
Disable threadId check about repeated thread creation.

### DIFF
--- a/lint/witnesslint/linter.py
+++ b/lint/witnesslint/linter.py
@@ -457,10 +457,11 @@ class WitnessLinter:
             pass
         elif key == witness.CREATETHREAD:
             if data.text in self.witness.threads:
-                logging.warning(
-                    "Thread with id {} has already been created".format(data.text),
-                    data.sourceline,
-                )
+                # logging.warning(
+                #     "Thread with id {} has already been created".format(data.text),
+                #     data.sourceline,
+                # )
+                pass
             else:
                 self.witness.threads[data.text] = None
         elif self.witness.defined_keys.get(key) == witness.EDGE:


### PR DESCRIPTION
See #33 for the problem and [here for the need of a seperate PR](https://github.com/sosy-lab/sv-witnesses/pull/34#pullrequestreview-547242803).

This fix would be nice for this year's SV-COMP, but it is not urgently necessary.
