### PR TITLE
Show overview of witness after linting.

### DIFF
--- a/lint/witnesslint/linter.py
+++ b/lint/witnesslint/linter.py
@@ -901,6 +901,7 @@ class WitnessLinter:
         if self.program_info is not None:
             for check in self.check_later:
                 check()
+        self.witness.show_witness_data()
 
     def lint(self):
         """

--- a/lint/witnesslint/witness.py
+++ b/lint/witnesslint/witness.py
@@ -119,3 +119,15 @@ class Witness:
             if re.match(termination_pattern, spec):
                 return True
         return False
+
+    def show_witness_data(self):
+        info = "Overview of checked witness:\n"
+        info += "Witness File: {}\n".format(self.witness_file)
+        info += "Witness Type: {}\n".format(self.witness_type)
+        info += "Producer: {}\n".format(self.producer)
+        info += "Creation Time: {}\n".format(self.creationtime)
+        info += "Architecture: {}\n".format(self.architecture)
+        info += "Program File: {}\n".format(self.programfile)
+        info += "Program Hash: {}\n".format(self.programhash)
+        info += "Source Code Language: {}\n".format(self.sourcecodelang)
+        print(info)


### PR DESCRIPTION
This PR adds a brief summary of the checked witness to each successfull linter run.

Addresses #55.
Not all the information listed in the example given in this issue are reported, since we currently do not collect all of it. However, the most important points are listed; in particular the linter outputs the requested `witness-type`.