### PR TITLE
Output linter version during execution

### DIFF
--- a/lint/witnesslint/linter.py
+++ b/lint/witnesslint/linter.py
@@ -11,7 +11,7 @@ with the GraphML-based witness format [1].
 [1]: github.com/sosy-lab/sv-witnesses/blob/main/README-GraphML.md
 """
 
-__version__ = "1.2"
+__version__ = "1.2-dev"
 
 import argparse
 import collections
@@ -994,18 +994,7 @@ def _exit(exit_code=None):
 def main(argv):
     try:
         linter = create_linter(argv[1:])
-        try:
-            import subprocess
-
-            revision = subprocess.run(
-                ["git", "describe", "--dirty"], capture_output=True, text=True
-            ).stdout
-            print(
-                "Running witnesslint version {0}, "
-                "Git-Revision {1}\n".format(__version__, revision)
-            )
-        except FileNotFoundError:
-            print("Running witnesslint version {}\n".format(__version__))
+        print("Running witnesslint version {}\n".format(__version__))
         linter.lint()
         _exit()
     except Exception as e:

--- a/lint/witnesslint/linter.py
+++ b/lint/witnesslint/linter.py
@@ -994,6 +994,7 @@ def _exit(exit_code=None):
 def main(argv):
     try:
         linter = create_linter(argv[1:])
+        print("Running witnesslint version {}\n".format(__version__))
         linter.lint()
         _exit()
     except Exception as e:

--- a/lint/witnesslint/linter.py
+++ b/lint/witnesslint/linter.py
@@ -17,7 +17,6 @@ import argparse
 import collections
 import hashlib
 import re
-import subprocess
 import sys
 
 from lxml import etree  # noqa: S410 does not matter
@@ -995,8 +994,18 @@ def _exit(exit_code=None):
 def main(argv):
     try:
         linter = create_linter(argv[1:])
-        revision = subprocess.run(["git", "describe", "--dirty"], capture_output=True, text=True).stdout
-        print("Running witnesslint version {0}, Git-Revision {1}\n".format(__version__, revision))
+        try:
+            import subprocess
+
+            revision = subprocess.run(
+                ["git", "describe", "--dirty"], capture_output=True, text=True
+            ).stdout
+            print(
+                "Running witnesslint version {0}, "
+                "Git-Revision {1}\n".format(__version__, revision)
+            )
+        except FileNotFoundError:
+            print("Running witnesslint version {}\n".format(__version__))
         linter.lint()
         _exit()
     except Exception as e:

--- a/lint/witnesslint/linter.py
+++ b/lint/witnesslint/linter.py
@@ -17,6 +17,7 @@ import argparse
 import collections
 import hashlib
 import re
+import subprocess
 import sys
 
 from lxml import etree  # noqa: S410 does not matter
@@ -994,7 +995,8 @@ def _exit(exit_code=None):
 def main(argv):
     try:
         linter = create_linter(argv[1:])
-        print("Running witnesslint version {}\n".format(__version__))
+        revision = subprocess.run(["git", "describe", "--dirty"], capture_output=True, text=True).stdout
+        print("Running witnesslint version {0}, Git-Revision {1}\n".format(__version__, revision))
         linter.lint()
         _exit()
     except Exception as e:


### PR DESCRIPTION
This PR adds version output to each run of the witness linter. To get more precise information about the used version, the current git revision is also appended when possible.

Closes #53.